### PR TITLE
ci: Use GITHUB_OUTPUT envvar instead of set-output command

### DIFF
--- a/.github/workflows/extension-publish.yml
+++ b/.github/workflows/extension-publish.yml
@@ -26,7 +26,7 @@ jobs:
           mv *.egg extension_archive.zip
           zip -r aws_stonebranch.zip extension_archive* template*
       - name: version
-        run: echo "::set-output name=version::$(python3 setup.py --version)"
+        run: echo "version=$(python3 setup.py --version)" >> "$GITHUB_OUTPUT"
         id: version
       - name: release
         uses: actions/create-release@v1


### PR DESCRIPTION
`save-state` and `set-output` commands used in GitHub Actions are deprecated and [GitHub recommends using environment files](https://github.blog/changelog/2023-07-24-github-actions-update-on-save-state-and-set-output-commands/).

This PR updates the usage of `::set-output` to `"$GITHUB_OUTPUT"`

Instructions for envvar usage from GitHub docs:

https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#setting-an-output-parameter